### PR TITLE
Add databases

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -19,8 +19,8 @@ repositories {
 
 dependencies {
     paperDevBundle("1.19.2-R0.1-SNAPSHOT")
-    //implementation("com.github.simplix-softworks:simplixstorage:3.2.4")
     implementation("org.spongepowered:configurate-yaml:4.1.2")
+    implementation("org.spongepowered:configurate-gson:4.1.2")
     implementation("org.spongepowered:configurate-extra-kotlin:4.1.2")
     implementation("cloud.commandframework:cloud-core:1.7.1")
     implementation("cloud.commandframework:cloud-paper:1.7.1")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -32,8 +32,8 @@ dependencies {
     implementation("net.kyori:adventure-extra-kotlin:4.11.0")
     implementation("org.apache.logging.log4j:log4j-api:2.19.0")
     implementation("org.apache.logging.log4j:log4j-core:2.19.0")
-    implementation("org.reflections:reflections:0.10.2")
-    implementation("org.mongodb:mongo-java-driver:3.12.11")
+    implementation("dev.morphia.morphia:morphia-core:2.2.9")
+
 }
 
 tasks {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-api:2.19.0")
     implementation("org.apache.logging.log4j:log4j-core:2.19.0")
     implementation("org.reflections:reflections:0.10.2")
+    implementation("org.mongodb:mongo-java-driver:3.12.11")
 }
 
 tasks {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,7 +33,9 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-api:2.19.0")
     implementation("org.apache.logging.log4j:log4j-core:2.19.0")
     implementation("dev.morphia.morphia:morphia-core:2.2.9")
-
+    implementation("org.postgresql:postgresql:42.5.0")
+    implementation("com.j256.ormlite:ormlite-core:6.1")
+    implementation("com.j256.ormlite:ormlite-jdbc:6.1")
 }
 
 tasks {

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/KitPvPPlus.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/KitPvPPlus.kt
@@ -38,7 +38,7 @@ class KitPvPPlus(val bukkit: Plugin) {
         // Load database
         database = when(settingsConfig.database.driver) {
             DatabaseConfigSettings.DataDriver.LOCAL_FILE -> LocalFileStorage(settingsConfig.database)
-            DatabaseConfigSettings.DataDriver.MYSQL -> TODO()
+            DatabaseConfigSettings.DataDriver.MYSQL -> MySQLDataStorage(settingsConfig.database)
             DatabaseConfigSettings.DataDriver.POSTGRES -> PostgresDataStorage(settingsConfig.database)
             DatabaseConfigSettings.DataDriver.MONGO -> MongoDataStorage(settingsConfig.database)
         }

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/KitPvPPlus.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/KitPvPPlus.kt
@@ -8,10 +8,7 @@ import org.bukkit.plugin.PluginManager
 import org.incendo.interfaces.paper.PaperInterfaceListeners
 import wtf.nucker.kitpvpplus.config.LangConfig
 import wtf.nucker.kitpvpplus.config.SettingsConfig
-import wtf.nucker.kitpvpplus.database.DataStorageMethod
-import wtf.nucker.kitpvpplus.database.DatabaseConfigSettings
-import wtf.nucker.kitpvpplus.database.LocalFileStorage
-import wtf.nucker.kitpvpplus.database.MongoDataStorage
+import wtf.nucker.kitpvpplus.database.*
 import wtf.nucker.kitpvpplus.manager.CommandManager
 import wtf.nucker.kitpvpplus.manager.ConfigManager
 import wtf.nucker.kitpvpplus.util.KotlinExtensions
@@ -42,7 +39,7 @@ class KitPvPPlus(val bukkit: Plugin) {
         database = when(settingsConfig.database.driver) {
             DatabaseConfigSettings.DataDriver.LOCAL_FILE -> LocalFileStorage(settingsConfig.database)
             DatabaseConfigSettings.DataDriver.MYSQL -> TODO()
-            DatabaseConfigSettings.DataDriver.POSTGRES -> TODO()
+            DatabaseConfigSettings.DataDriver.POSTGRES -> PostgresDataStorage(settingsConfig.database)
             DatabaseConfigSettings.DataDriver.MONGO -> MongoDataStorage(settingsConfig.database)
         }
 

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/KitPvPPlus.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/KitPvPPlus.kt
@@ -37,7 +37,7 @@ class KitPvPPlus(val bukkit: Plugin) {
 
         // Load database
         database = when(settingsConfig.database.driver) {
-            DatabaseConfigSettings.DataDriver.LOCAL_FILE -> LocalFileStorage(settingsConfig.database)
+            DatabaseConfigSettings.DataDriver.LOCAL_STORAGE -> LocalFileStorage(settingsConfig.database)
             DatabaseConfigSettings.DataDriver.MYSQL -> MySQLDataStorage(settingsConfig.database)
             DatabaseConfigSettings.DataDriver.POSTGRES -> PostgresDataStorage(settingsConfig.database)
             DatabaseConfigSettings.DataDriver.MONGO -> MongoDataStorage(settingsConfig.database)
@@ -56,9 +56,8 @@ class KitPvPPlus(val bukkit: Plugin) {
         }
     }
 
-
-
     fun onServerShutdown() {
         logger.info("KitPvPPlus is now shutting down")
+        database.disconnect()
     }
 }

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/KitPvPPlus.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/KitPvPPlus.kt
@@ -11,10 +11,10 @@ import wtf.nucker.kitpvpplus.config.SettingsConfig
 import wtf.nucker.kitpvpplus.database.DataStorageMethod
 import wtf.nucker.kitpvpplus.database.DatabaseConfigSettings
 import wtf.nucker.kitpvpplus.database.LocalFileStorage
+import wtf.nucker.kitpvpplus.database.MongoDataStorage
 import wtf.nucker.kitpvpplus.manager.CommandManager
 import wtf.nucker.kitpvpplus.manager.ConfigManager
 import wtf.nucker.kitpvpplus.util.KotlinExtensions
-import wtf.nucker.kitpvpplus.util.KotlinExtensions.component
 import wtf.nucker.kitpvpplus.util.KotlinExtensions.editPlayerData
 import wtf.nucker.kitpvpplus.util.KotlinExtensions.logger
 import wtf.nucker.kitpvpplus.util.KotlinExtensions.playerData
@@ -43,7 +43,7 @@ class KitPvPPlus(val bukkit: Plugin) {
             DatabaseConfigSettings.DataDriver.LOCAL_FILE -> LocalFileStorage(settingsConfig.database)
             DatabaseConfigSettings.DataDriver.MYSQL -> TODO()
             DatabaseConfigSettings.DataDriver.POSTGRES -> TODO()
-            DatabaseConfigSettings.DataDriver.MONGO -> TODO()
+            DatabaseConfigSettings.DataDriver.MONGO -> MongoDataStorage(settingsConfig.database)
         }
 
         PaperInterfaceListeners.install(bukkit)

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/config/SettingsConfig.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/config/SettingsConfig.kt
@@ -1,9 +1,10 @@
 package wtf.nucker.kitpvpplus.config
 
 import org.spongepowered.configurate.objectmapping.ConfigSerializable
+import wtf.nucker.kitpvpplus.database.DatabaseConfigSettings
 
 @ConfigSerializable
 class SettingsConfig {
 
-
+    val database: DatabaseConfigSettings = DatabaseConfigSettings()
 }

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/DataStorageMethod.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/DataStorageMethod.kt
@@ -15,4 +15,6 @@ interface DataStorageMethod {
     fun updatePlayerData(player: Player, data: PlayerData) = updatePlayerData(player.uniqueId, data)
 
     fun updatePlayerData(uuid: UUID, data: PlayerData)
+
+    fun disconnect()
 }

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/DataStorageMethod.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/DataStorageMethod.kt
@@ -1,0 +1,18 @@
+package wtf.nucker.kitpvpplus.database
+
+import org.bukkit.entity.Player
+import wtf.nucker.kitpvpplus.`object`.PlayerData
+import java.util.*
+
+interface DataStorageMethod {
+
+    val configSettings: DatabaseConfigSettings
+
+    fun getPlayerData(player: Player): PlayerData = getPlayerData(player.uniqueId)
+
+    fun getPlayerData(uuid: UUID): PlayerData
+
+    fun updatePlayerData(player: Player, data: PlayerData) = updatePlayerData(player.uniqueId, data)
+
+    fun updatePlayerData(uuid: UUID, data: PlayerData)
+}

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/DatabaseConfigSettings.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/DatabaseConfigSettings.kt
@@ -5,7 +5,7 @@ import org.spongepowered.configurate.objectmapping.meta.Comment
 
 @ConfigSerializable
 data class DatabaseConfigSettings(
-    val driver: DataDriver = DataDriver.LOCAL_FILE,
+    val driver: DataDriver = DataDriver.LOCAL_STORAGE,
     val host: String? = null,
     val port: Int? = null,
     @Comment("Only needed for SQL-based databases")
@@ -20,7 +20,7 @@ data class DatabaseConfigSettings(
     )
 
     enum class DataDriver {
-        LOCAL_FILE, MYSQL, POSTGRES, MONGO
+        LOCAL_STORAGE, MYSQL, POSTGRES, MONGO
     }
 }
 

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/DatabaseConfigSettings.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/DatabaseConfigSettings.kt
@@ -1,0 +1,27 @@
+package wtf.nucker.kitpvpplus.database
+
+import org.spongepowered.configurate.objectmapping.ConfigSerializable
+import org.spongepowered.configurate.objectmapping.meta.Comment
+
+@ConfigSerializable
+data class DatabaseConfigSettings(
+    val driver: DataDriver = DataDriver.LOCAL_FILE,
+    val host: String? = null,
+    val port: Int? = null,
+    @Comment("Only needed for SQL-based databases")
+    val database: String? = null,
+    val authentication: DatabaseAuthenticationSettings = DatabaseAuthenticationSettings()
+) {
+    @ConfigSerializable
+    data class DatabaseAuthenticationSettings(
+        val enabled: Boolean = false,
+        val username: String = "",
+        val password: String = ""
+    )
+
+    enum class DataDriver {
+        LOCAL_FILE, MYSQL, POSTGRES, MONGO
+    }
+}
+
+

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/LocalFileStorage.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/LocalFileStorage.kt
@@ -35,4 +35,8 @@ class LocalFileStorage(override val configSettings: DatabaseConfigSettings) : Da
         loader.save(configNode)
     }
 
+    override fun disconnect() {
+        loader.save(configNode)
+    }
+
 }

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/LocalFileStorage.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/LocalFileStorage.kt
@@ -1,0 +1,40 @@
+package wtf.nucker.kitpvpplus.database
+
+import org.spongepowered.configurate.BasicConfigurationNode
+import org.spongepowered.configurate.CommentedConfigurationNode
+import org.spongepowered.configurate.gson.GsonConfigurationLoader
+import org.spongepowered.configurate.yaml.YamlConfigurationLoader
+import wtf.nucker.kitpvpplus.manager.ConfigManager
+import wtf.nucker.kitpvpplus.`object`.PlayerData
+import wtf.nucker.kitpvpplus.util.KotlinExtensions.logger
+import java.util.*
+
+class LocalFileStorage(override val configSettings: DatabaseConfigSettings) : DataStorageMethod {
+
+    private val loader: GsonConfigurationLoader
+    private val configNode: BasicConfigurationNode
+
+    init {
+        logger.warn("!-----WARNING-----!")
+        logger.warn("YOU ARE USING THE LOCAL DATA STORAGE DRIVER FOR KITPVPPLUS.")
+        logger.warn("IF YOU ARE USING THIS PLUGIN IN A PRODUCTION ENVIRONMENT, WE ADVISE YOU USE A DATABASE.")
+        logger.warn("PAPER LIMITS THE MAX SIZE OF A FILE. SO ONLY USE THIS FOR TESTING AND SMALL SERVERS (IF THAT)")
+        logger.warn("YOU HAVE BEEN WARNED")
+
+        logger.info("Loading data.json")
+        loader = ConfigManager.retrieveLoaderJson("data.json").also { logger.debug("Loaded data.json") }
+        configNode = loader.load().also { logger.debug("Loaded root node") }
+        loader.save(configNode)
+    }
+
+    override fun getPlayerData(uuid: UUID): PlayerData {
+        //if(configNode.node(uuid).get(PlayerData::class.java) == null) this.updatePlayerData(uuid, PlayerData())
+        return configNode.node(uuid.toString()).get(PlayerData::class.java)!!
+    }
+
+    override fun updatePlayerData(uuid: UUID, data: PlayerData) {
+        configNode.node(uuid.toString()).set(data::class.java, data)
+        loader.save(configNode)
+    }
+
+}

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/LocalFileStorage.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/LocalFileStorage.kt
@@ -1,9 +1,7 @@
 package wtf.nucker.kitpvpplus.database
 
 import org.spongepowered.configurate.BasicConfigurationNode
-import org.spongepowered.configurate.CommentedConfigurationNode
 import org.spongepowered.configurate.gson.GsonConfigurationLoader
-import org.spongepowered.configurate.yaml.YamlConfigurationLoader
 import wtf.nucker.kitpvpplus.manager.ConfigManager
 import wtf.nucker.kitpvpplus.`object`.PlayerData
 import wtf.nucker.kitpvpplus.util.KotlinExtensions.logger
@@ -19,7 +17,7 @@ class LocalFileStorage(override val configSettings: DatabaseConfigSettings) : Da
         logger.warn("YOU ARE USING THE LOCAL DATA STORAGE DRIVER FOR KITPVPPLUS.")
         logger.warn("IF YOU ARE USING THIS PLUGIN IN A PRODUCTION ENVIRONMENT, WE ADVISE YOU USE A DATABASE.")
         logger.warn("PAPER LIMITS THE MAX SIZE OF A FILE. SO ONLY USE THIS FOR TESTING AND SMALL SERVERS (IF THAT)")
-        logger.warn("YOU HAVE BEEN WARNED")
+        logger.warn("YOU HAVE BEEN WARNED...")
 
         logger.info("Loading data.json")
         loader = ConfigManager.retrieveLoaderJson("data.json").also { logger.debug("Loaded data.json") }

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/MongoDataStorage.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/MongoDataStorage.kt
@@ -1,0 +1,66 @@
+package wtf.nucker.kitpvpplus.database
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.mongodb.MongoClient
+import com.mongodb.MongoClientURI
+import com.mongodb.client.MongoCollection
+import com.mongodb.client.MongoDatabase
+import org.bson.Document
+import wtf.nucker.kitpvpplus.`object`.PlayerData
+import wtf.nucker.kitpvpplus.util.KotlinExtensions.logger
+import java.util.*
+
+class MongoDataStorage(override val configSettings: DatabaseConfigSettings) : DataStorageMethod {
+
+    private val database: MongoCollection<Document>
+    private val gson = Gson()
+
+    init {
+        logger.info("Loading MongoDB database")
+        try {
+            configSettings.host!!
+            configSettings.port!!
+            configSettings.database!!
+        }catch (ex: NullPointerException) {
+            logger.error("If you are seeing this, you have missed out a crucial piece of information in your config.")
+            logger.error("Please make sure your host, port & database is defined in the settings.yml")
+            throw NullPointerException(ex.message)
+        }
+        val connectionString: String = if(configSettings.authentication.enabled) {
+            "mongodb://${configSettings.authentication.username}:${configSettings.authentication.password}@${configSettings.host}:${configSettings.port}"
+        } else {
+            "mongodb://${configSettings.host}:${configSettings.port}"
+        }
+
+        val client = MongoClient(MongoClientURI(connectionString))
+        val mongoDb: MongoDatabase = client.getDatabase(configSettings.database)
+        database = mongoDb.getCollection(configSettings.database)
+    }
+
+    override fun getPlayerData(uuid: UUID): PlayerData {
+        if(database.find(Document("_id", uuid.toString())).first() == null) {
+            return PlayerData().also {
+                database.insertOne(Document.parse(serializePlayerData(it, uuid)))
+            }
+        }
+
+       return this.deserializePlayerData(database.find(Document("_id", uuid.toString())).first()!!.toJson())
+    }
+
+    override fun updatePlayerData(uuid: UUID, data: PlayerData) {
+        database.replaceOne(Document("_id", uuid.toString()), Document.parse(serializePlayerData(data, uuid)))
+    }
+
+    private fun serializePlayerData(playerData: PlayerData, uuid: UUID): String {
+        val data: JsonObject = gson.toJsonTree(playerData) as JsonObject
+        data.addProperty("_id", uuid.toString())
+        return gson.toJson(data)
+    }
+
+    private fun deserializePlayerData(dataStr: String): PlayerData {
+        val data: JsonObject = gson.fromJson(dataStr, JsonObject::class.java)
+        data.remove("_id")
+        return gson.fromJson(data, PlayerData::class.java)
+    }
+}

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/MongoDataStorage.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/MongoDataStorage.kt
@@ -43,6 +43,10 @@ class MongoDataStorage(override val configSettings: DatabaseConfigSettings) : Da
         datastore.save(data)
     }
 
+    override fun disconnect() {
+        datastore.session?.close()
+    }
+
 
     //    private val database: MongoCollection<Document>
 //    private val gson = Gson()

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/MongoDataStorage.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/MongoDataStorage.kt
@@ -1,20 +1,16 @@
 package wtf.nucker.kitpvpplus.database
 
-import com.google.gson.Gson
-import com.google.gson.JsonObject
-import com.mongodb.MongoClient
-import com.mongodb.MongoClientURI
-import com.mongodb.client.MongoCollection
-import com.mongodb.client.MongoDatabase
-import org.bson.Document
+import com.mongodb.client.MongoClients
+import dev.morphia.Datastore
+import dev.morphia.Morphia
+import dev.morphia.query.experimental.filters.Filters
 import wtf.nucker.kitpvpplus.`object`.PlayerData
 import wtf.nucker.kitpvpplus.util.KotlinExtensions.logger
 import java.util.*
 
 class MongoDataStorage(override val configSettings: DatabaseConfigSettings) : DataStorageMethod {
 
-    private val database: MongoCollection<Document>
-    private val gson = Gson()
+    private val datastore: Datastore
 
     init {
         logger.info("Loading MongoDB database")
@@ -33,34 +29,69 @@ class MongoDataStorage(override val configSettings: DatabaseConfigSettings) : Da
             "mongodb://${configSettings.host}:${configSettings.port}"
         }
 
-        val client = MongoClient(MongoClientURI(connectionString))
-        val mongoDb: MongoDatabase = client.getDatabase(configSettings.database)
-        database = mongoDb.getCollection(configSettings.database)
+        datastore = Morphia.createDatastore(MongoClients.create(connectionString), configSettings.database)
+        datastore.mapper.map(PlayerData::class.java)
     }
 
     override fun getPlayerData(uuid: UUID): PlayerData {
-        if(database.find(Document("_id", uuid.toString())).first() == null) {
-            return PlayerData().also {
-                database.insertOne(Document.parse(serializePlayerData(it, uuid)))
-            }
-        }
-
-       return this.deserializePlayerData(database.find(Document("_id", uuid.toString())).first()!!.toJson())
+        return datastore
+            .find(PlayerData::class.java)
+            .filter(Filters.eq("_id", uuid.toString())).first() ?: return PlayerData(uuid = uuid.toString()).also { datastore.save(it) }
     }
 
     override fun updatePlayerData(uuid: UUID, data: PlayerData) {
-        database.replaceOne(Document("_id", uuid.toString()), Document.parse(serializePlayerData(data, uuid)))
+        datastore.save(data)
     }
 
-    private fun serializePlayerData(playerData: PlayerData, uuid: UUID): String {
-        val data: JsonObject = gson.toJsonTree(playerData) as JsonObject
-        data.addProperty("_id", uuid.toString())
-        return gson.toJson(data)
-    }
 
-    private fun deserializePlayerData(dataStr: String): PlayerData {
-        val data: JsonObject = gson.fromJson(dataStr, JsonObject::class.java)
-        data.remove("_id")
-        return gson.fromJson(data, PlayerData::class.java)
-    }
+    //    private val database: MongoCollection<Document>
+//    private val gson = Gson()
+//
+//    init {
+//        logger.info("Loading MongoDB database")
+//        try {
+//            configSettings.host!!
+//            configSettings.port!!
+//            configSettings.database!!
+//        }catch (ex: NullPointerException) {
+//            logger.error("If you are seeing this, you have missed out a crucial piece of information in your config.")
+//            logger.error("Please make sure your host, port & database is defined in the settings.yml")
+//            throw NullPointerException(ex.message)
+//        }
+//        val connectionString: String = if(configSettings.authentication.enabled) {
+//            "mongodb://${configSettings.authentication.username}:${configSettings.authentication.password}@${configSettings.host}:${configSettings.port}"
+//        } else {
+//            "mongodb://${configSettings.host}:${configSettings.port}"
+//        }
+//
+//        val client = MongoClient(MongoClientURI(connectionString))
+//        val mongoDb: MongoDatabase = client.getDatabase(configSettings.database)
+//        database = mongoDb.getCollection(configSettings.database)
+//    }
+//
+//    override fun getPlayerData(uuid: UUID): PlayerData {
+//        if(database.find(Document("_id", uuid.toString())).first() == null) {
+//            return PlayerData(uuid).also {
+//                database.insertOne(Document.parse(serializePlayerData(it, uuid)))
+//            }
+//        }
+//
+//       return this.deserializePlayerData(database.find(Document("_id", uuid.toString())).first()!!.toJson())
+//    }
+//
+//    override fun updatePlayerData(uuid: UUID, data: PlayerData) {
+//        database.replaceOne(Document("_id", uuid.toString()), Document.parse(serializePlayerData(data, uuid)))
+//    }
+//
+//    private fun serializePlayerData(playerData: PlayerData, uuid: UUID): String {
+//        val data: JsonObject = gson.toJsonTree(playerData) as JsonObject
+//        data.addProperty("_id", uuid.toString())
+//        return gson.toJson(data)
+//    }
+//
+//    private fun deserializePlayerData(dataStr: String): PlayerData {
+//        val data: JsonObject = gson.fromJson(dataStr, JsonObject::class.java)
+//        data.remove("_id")
+//        return gson.fromJson(data, PlayerData::class.java)
+//    }
 }

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/MySQLDataStorage.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/MySQLDataStorage.kt
@@ -43,4 +43,8 @@ class MySQLDataStorage(override val configSettings: DatabaseConfigSettings) : Da
     override fun updatePlayerData(uuid: UUID, data: PlayerData) {
         dao.update(data)
     }
+
+    override fun disconnect() {
+        connection.closeQuietly()
+    }
 }

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/MySQLDataStorage.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/MySQLDataStorage.kt
@@ -1,0 +1,46 @@
+package wtf.nucker.kitpvpplus.database
+
+import com.j256.ormlite.dao.Dao
+import com.j256.ormlite.dao.DaoManager
+import com.j256.ormlite.jdbc.JdbcConnectionSource
+import com.j256.ormlite.table.TableUtils
+import wtf.nucker.kitpvpplus.`object`.PlayerData
+import wtf.nucker.kitpvpplus.util.KotlinExtensions.logger
+import java.util.*
+
+class MySQLDataStorage(override val configSettings: DatabaseConfigSettings) : DataStorageMethod {
+
+    private val connection: JdbcConnectionSource
+    private val dao: Dao<PlayerData, String>
+
+    init {
+        try {
+            configSettings.host!!
+            configSettings.port!!
+            configSettings.database!!
+        }catch (ex: NullPointerException) {
+            logger.error("If you are seeing this, you have missed out a crucial piece of information in your config.")
+            logger.error("Please make sure your host, port & database is defined in the settings.yml")
+            throw NullPointerException(ex.message)
+        }
+
+        connection = if(configSettings.authentication.enabled) {
+            JdbcConnectionSource(
+                "jdbc:mysql://${configSettings.host}:${configSettings.port}/${configSettings.database}",
+                configSettings.authentication.username, configSettings.authentication.password)
+        }else {
+            JdbcConnectionSource("jdbc:mysql://${configSettings.host}:${configSettings.port}/${configSettings.database}")
+        }
+        dao = DaoManager.createDao(connection, PlayerData::class.java)
+        TableUtils.createTableIfNotExists(connection, PlayerData::class.java)
+    }
+
+    override fun getPlayerData(uuid: UUID): PlayerData {
+        dao.createIfNotExists(PlayerData(uuid = uuid.toString()))
+        return dao.queryForId(uuid.toString())
+    }
+
+    override fun updatePlayerData(uuid: UUID, data: PlayerData) {
+        dao.update(data)
+    }
+}

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/PostgresDataStorage.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/PostgresDataStorage.kt
@@ -43,4 +43,8 @@ class PostgresDataStorage(override val configSettings: DatabaseConfigSettings) :
     override fun updatePlayerData(uuid: UUID, data: PlayerData) {
         dao.update(data)
     }
+
+    override fun disconnect() {
+        connection.closeQuietly()
+    }
 }

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/PostgresDataStorage.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/database/PostgresDataStorage.kt
@@ -1,0 +1,46 @@
+package wtf.nucker.kitpvpplus.database
+
+import com.j256.ormlite.dao.Dao
+import com.j256.ormlite.dao.DaoManager
+import com.j256.ormlite.jdbc.JdbcConnectionSource
+import com.j256.ormlite.table.TableUtils
+import wtf.nucker.kitpvpplus.`object`.PlayerData
+import wtf.nucker.kitpvpplus.util.KotlinExtensions.logger
+import java.util.*
+
+class PostgresDataStorage(override val configSettings: DatabaseConfigSettings) : DataStorageMethod {
+
+    private val connection: JdbcConnectionSource
+    private val dao: Dao<PlayerData, String>
+
+    init {
+        try {
+            configSettings.host!!
+            configSettings.port!!
+            configSettings.database!!
+        }catch (ex: NullPointerException) {
+            logger.error("If you are seeing this, you have missed out a crucial piece of information in your config.")
+            logger.error("Please make sure your host, port & database is defined in the settings.yml")
+            throw NullPointerException(ex.message)
+        }
+
+        connection = if(configSettings.authentication.enabled) {
+            JdbcConnectionSource(
+                "jdbc:postgresql://${configSettings.host}:${configSettings.port}/${configSettings.database}",
+                configSettings.authentication.username, configSettings.authentication.password)
+        }else {
+            JdbcConnectionSource("jdbc:postgresql://${configSettings.host}:${configSettings.port}/${configSettings.database}")
+        }
+        dao = DaoManager.createDao(connection, PlayerData::class.java)
+        TableUtils.createTableIfNotExists(connection, PlayerData::class.java)
+    }
+
+    override fun getPlayerData(uuid: UUID): PlayerData {
+        dao.createIfNotExists(PlayerData(uuid = uuid.toString()))
+        return dao.queryForId(uuid.toString())
+    }
+
+    override fun updatePlayerData(uuid: UUID, data: PlayerData) {
+        dao.update(data)
+    }
+}

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/manager/ConfigManager.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/manager/ConfigManager.kt
@@ -2,6 +2,7 @@ package wtf.nucker.kitpvpplus.manager
 
 import org.bukkit.Bukkit
 import org.spongepowered.configurate.CommentedConfigurationNode
+import org.spongepowered.configurate.gson.GsonConfigurationLoader
 import org.spongepowered.configurate.serialize.TypeSerializerCollection
 import org.spongepowered.configurate.yaml.NodeStyle
 import org.spongepowered.configurate.yaml.YamlConfigurationLoader
@@ -10,7 +11,6 @@ import wtf.nucker.kitpvpplus.adapter.LocaleAdapter
 import wtf.nucker.kitpvpplus.adapter.register
 import wtf.nucker.kitpvpplus.util.KotlinExtensions.logger
 import java.nio.file.Path
-import java.util.function.Consumer
 
 
 object ConfigManager {
@@ -23,7 +23,7 @@ object ConfigManager {
 
     inline fun <reified T : Any> loadConfig(name: String): T {
         logger.info("Loading $name")
-        val loader: YamlConfigurationLoader = retrieveLoader(name)
+        val loader: YamlConfigurationLoader = retrieveLoaderYaml(name)
 
         val node: CommentedConfigurationNode = loader.load()
         val config = node.get(T::class.java)!!
@@ -33,7 +33,7 @@ object ConfigManager {
 
     fun <T : Any> reloadConfig(name: String, configClass: T) {
         logger.info("Saving $name with ${configClass::class.qualifiedName}#${configClass.hashCode()}")
-        val loader: YamlConfigurationLoader = retrieveLoader(name)
+        val loader: YamlConfigurationLoader = retrieveLoaderYaml(name)
 
         val node: CommentedConfigurationNode = loader.load()
         val config = node.get(configClass::class.java)!!
@@ -42,7 +42,7 @@ object ConfigManager {
         loader.save(node)
     }
 
-    fun retrieveLoader(name: String): YamlConfigurationLoader = YamlConfigurationLoader.builder()
+    fun retrieveLoaderYaml(name: String): YamlConfigurationLoader = YamlConfigurationLoader.builder()
         .path(Path.of(Bukkit.getPluginsFolder().absolutePath, FOLDER_NAME, name))
         .defaultOptions {
             it.shouldCopyDefaults(true)
@@ -52,5 +52,16 @@ object ConfigManager {
         }
         .indent(4)
         .nodeStyle(NodeStyle.BLOCK)
+        .build()
+
+    fun retrieveLoaderJson(name: String): GsonConfigurationLoader = GsonConfigurationLoader.builder()
+        .path(Path.of(Bukkit.getPluginsFolder().absolutePath, FOLDER_NAME, name))
+        .defaultOptions {
+            it.shouldCopyDefaults(true)
+            it.serializers { builder ->
+                builder.registerAll(serializers)
+            }
+        }
+        .indent(4)
         .build()
 }

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/object/PlayerData.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/object/PlayerData.kt
@@ -1,16 +1,19 @@
 package wtf.nucker.kitpvpplus.`object`
 
+import com.j256.ormlite.field.DatabaseField
+import com.j256.ormlite.table.DatabaseTable
 import dev.morphia.annotations.Entity
 import dev.morphia.annotations.Id
 import org.spongepowered.configurate.objectmapping.ConfigSerializable
 import java.util.*
 
 @Entity("PlayerData")
+@DatabaseTable(tableName = "playerdata")
 @ConfigSerializable
 data class PlayerData(
-    @Id val uuid: String? = null /*** UUID must not be null for databases. Only for local storage. */,
-    var exp: Double = 0.0,
-    var money: Double = 0.0,
-    var kills: Int = 0,
-    var deaths: Int = 0
+    @Id @DatabaseField(id = true) val uuid: String? = null /*** UUID must not be null for databases. Only for local storage. */ ,
+    @DatabaseField var exp: Double = 0.0,
+    @DatabaseField var money: Double = 0.0,
+    @DatabaseField var kills: Int = 0,
+    @DatabaseField var deaths: Int = 0
 )

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/object/PlayerData.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/object/PlayerData.kt
@@ -1,9 +1,14 @@
 package wtf.nucker.kitpvpplus.`object`
 
+import dev.morphia.annotations.Entity
+import dev.morphia.annotations.Id
 import org.spongepowered.configurate.objectmapping.ConfigSerializable
+import java.util.*
 
+@Entity("PlayerData")
 @ConfigSerializable
 data class PlayerData(
+    @Id val uuid: String? = null /*** UUID must not be null for databases. Only for local storage. */,
     var exp: Double = 0.0,
     var money: Double = 0.0,
     var kills: Int = 0,

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/object/PlayerData.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/object/PlayerData.kt
@@ -1,0 +1,11 @@
+package wtf.nucker.kitpvpplus.`object`
+
+import org.spongepowered.configurate.objectmapping.ConfigSerializable
+
+@ConfigSerializable
+data class PlayerData(
+    var exp: Double = 0.0,
+    var money: Double = 0.0,
+    var kills: Int = 0,
+    var deaths: Int = 0
+)

--- a/core/src/main/kotlin/wtf/nucker/kitpvpplus/util/KotlinExtensions.kt
+++ b/core/src/main/kotlin/wtf/nucker/kitpvpplus/util/KotlinExtensions.kt
@@ -4,8 +4,12 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
+import org.bukkit.entity.Player
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import wtf.nucker.kitpvpplus.KitPvPPlus
+import wtf.nucker.kitpvpplus.`object`.PlayerData
+import java.util.function.Consumer
 
 /**
  *
@@ -15,7 +19,17 @@ import org.slf4j.LoggerFactory
  */
 object KotlinExtensions {
 
+    lateinit var plugin: KitPvPPlus
 
+    var Player.playerData
+        get() = plugin.database.getPlayerData(this)
+        set(data) = plugin.database.updatePlayerData(this, data)
+
+    fun Player.editPlayerData(editor: Consumer<PlayerData>) {
+        val data = playerData
+        editor.accept(data)
+        playerData = data
+    }
     val Any.logger: Logger
         get() = LoggerFactory.getLogger(this::class.java)
 


### PR DESCRIPTION
Adds database and player data. Support for the following databases:
- Local file
- MySQL
- PostgreSQL
- MongoDB
All serializing the `PlayerData` data class.